### PR TITLE
「HTML設定」のヨミガナを修正

### DIFF
--- a/nadesiko3-htmlparser.js
+++ b/nadesiko3-htmlparser.js
@@ -140,7 +140,7 @@ export default {
       return o.html()
     }
   },
-  'HTML設定': { // @DOMにSを設定する // @HTML設定
+  'HTML設定': { // @DOMにSを設定する // @HTMLせってい
     type: 'func',
     josi: [['に', 'へ'], ['を']],
     fn: function (dom, s, sys) {


### PR DESCRIPTION
ヨミガナに混ざっていた漢字をひらがなに修正。
